### PR TITLE
Release v0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 
@@ -43,3 +45,23 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  binaries:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env.*
 .DS_Store
 .claude/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,62 @@
+version: 2
+
+project_name: rss-fulltext
+
+builds:
+  - id: rss-fulltext
+    main: ./
+    binary: rss-fulltext
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .ShortCommit }}
+      - -X main.date={{ .CommitDate }}
+    goos:
+      - linux
+      - darwin
+      - freebsd
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+archives:
+  - id: default
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: '{{ incpatch .Version }}-snapshot'
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^test:'
+      - 'Merge pull request'
+      - 'Merge branch'
+
+release:
+  draft: false
+  prerelease: auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ COPY --from=build --chown=nonroot:nonroot /out/data /var/lib/rss-fulltext
 EXPOSE 8080
 USER nonroot:nonroot
 VOLUME ["/var/lib/rss-fulltext"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/usr/local/bin/rss-fulltext", "healthcheck"]
 ENTRYPOINT ["/usr/local/bin/rss-fulltext"]

--- a/README.md
+++ b/README.md
@@ -6,18 +6,59 @@ means a browser, an ad-loaded layout, and an internet connection.
 
 `rss-fulltext` rewrites those feeds so the full article body travels with the
 feed itself. For each entry it fetches the linked page, pulls the main content
-out with readability, sanitises it, and writes the enriched feed to disk as
-`<name>.xml`. Files are regenerated on a per-feed schedule and served as
-static XML over HTTP.
+out with readability, sanitises it, and writes the enriched feed to disk in
+three formats: RSS (`<name>.xml`), Atom (`<name>.atom`), and JSON Feed
+(`<name>.json`). Files are regenerated on a per-feed schedule and served as
+static files over HTTP.
 
 Useful when you want to:
 
 - **Read offline.** Articles ship with the feed.
 - **Read on an e-reader.** Full text instead of a link to a page your e-reader can't render.
 - **Escape publisher chrome.** No popovers, ads, or newsletter modals.
-- **Archive what you read.** Each refresh writes a plain XML file to disk.
+- **Archive what you read.** Each refresh writes plain files to disk.
 
 ## Quick start
+
+### One-line Docker
+
+```sh
+curl -O https://raw.githubusercontent.com/mijndert/rss-fulltext/main/feeds.yaml
+docker run -d --name rss-fulltext \
+  -p 127.0.0.1:8080:8080 \
+  -v "$PWD/feeds.yaml:/etc/rss-fulltext/feeds.yaml:ro" \
+  -v rss-fulltext-data:/var/lib/rss-fulltext \
+  -e LISTEN_ADDR=:8080 \
+  -e CONFIG_PATH=/etc/rss-fulltext/feeds.yaml \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges:true \
+  ghcr.io/mijndert/rss-fulltext:latest
+```
+
+The `--read-only`, `--cap-drop=ALL`, and `--security-opt=no-new-privileges`
+flags match the hardening that Compose applies by default — the named volume
+remains writable for the cache and generated feeds.
+
+That's it. After a few seconds:
+
+```sh
+curl http://127.0.0.1:8080/feeds.json | jq
+```
+
+Endpoints:
+
+- `http://127.0.0.1:8080/<name>.xml` — RSS 2.0
+- `http://127.0.0.1:8080/<name>.atom` — Atom
+- `http://127.0.0.1:8080/<name>.json` — JSON Feed
+- `http://127.0.0.1:8080/feeds.json` — status of every configured feed
+- `http://127.0.0.1:8080/metrics` — Prometheus metrics
+- `http://127.0.0.1:8080/healthz` — liveness probe
+
+### Docker Compose
+
+If you'd rather use Compose (gets you the locked-down `read_only`, `cap_drop`,
+`no-new-privileges` defaults out of the box):
 
 ```sh
 git clone https://github.com/mijndert/rss-fulltext.git
@@ -25,15 +66,26 @@ cd rss-fulltext
 docker compose up -d
 ```
 
-The default `feeds.yaml` ships with three example feeds. On first start the
-service refreshes each one (staggered) and exposes:
+Compose binds the published port to loopback (`127.0.0.1:8080`). To expose
+externally, put a reverse proxy in front of it — see [Reverse proxy](#reverse-proxy)
+below.
 
-- `http://127.0.0.1:8080/<name>.xml` — the enriched RSS for each feed
-- `http://127.0.0.1:8080/feeds.json` — status of every configured feed
-- `http://127.0.0.1:8080/healthz` — liveness probe
+### Pre-built binary
 
-Compose binds to loopback (`127.0.0.1:8080`). To expose externally, put a
-reverse proxy in front (Caddy, nginx, Traefik) and terminate TLS there.
+Each tagged release ships linux/macOS/FreeBSD binaries for amd64 and arm64 on
+the [Releases page](https://github.com/mijndert/rss-fulltext/releases). Verify
+the tarball against `checksums.txt`, extract, and run:
+
+```sh
+CONFIG_PATH=./feeds.yaml OUTPUT_DIR=./out CACHE_DIR=./cache ./rss-fulltext
+```
+
+The binary also accepts a few subcommands:
+
+```sh
+rss-fulltext version       # print version, commit, build date
+rss-fulltext healthcheck   # probe /healthz on the local port, exit 0 if healthy
+```
 
 ## Configuration
 
@@ -57,17 +109,20 @@ Edit `feeds.yaml` and restart the container to pick up changes:
 
 ```sh
 docker compose restart
+# or for the one-line run above:
+docker restart rss-fulltext
 ```
 
 ## Environment variables
 
-All have defaults in `docker-compose.yml`. Override there or with `.env`.
+All have defaults; override via `-e` on `docker run`, the `environment:` block
+in Compose, or the process environment for the bare binary.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `LISTEN_ADDR` | `:8080` in compose, `127.0.0.1:8080` for the bare binary | the bare-binary default binds loopback only |
-| `CONFIG_PATH` | `/etc/rss-fulltext/feeds.yaml` | mounted from `./feeds.yaml` |
-| `OUTPUT_DIR` | `/var/lib/rss-fulltext/feeds` | where `<name>.xml` files land |
+| `LISTEN_ADDR` | `127.0.0.1:8080` (binary), `:8080` (compose) | bare binary binds loopback only — set `:8080` to listen on all interfaces in containers |
+| `CONFIG_PATH` | (required) | path to `feeds.yaml` |
+| `OUTPUT_DIR` | `/var/lib/rss-fulltext/feeds` | where `<name>.xml`, `<name>.atom`, `<name>.json` files land |
 | `CACHE_DIR` | `/var/lib/rss-fulltext/cache` | per-article cache; sha256 keys |
 | `CACHE_TTL` | `24h` | how long a fetched article body stays cached; `0` disables caching |
 | `JANITOR_INTERVAL` | `1h` | how often expired cache files are purged; `0` disables the janitor |
@@ -79,13 +134,70 @@ All have defaults in `docker-compose.yml`. Override there or with `.env`.
 | `MAX_ARTICLE_BYTES` | `5242880` | hard cap on body read by readability |
 | `MAX_FEED_BYTES` | `4194304` | hard cap on the source-feed XML |
 | `MAX_ITEMS_PER_FEED` | `50` | truncate longer feeds |
+| `NEGATIVE_CACHE_TTL` | `1h` | how long extractor errors are cached |
+| `MAX_STALENESS` | `24h` | how long to keep serving the previous file when upstream returns 0 items |
 | `USER_AGENT` | `rss-fulltext/2.0` | sent on every outbound fetch |
 | `ALLOW_PRIVATE_ADDRESSES` | `false` | set `true` only for local testing — disables the SSRF guard |
+
+## Reverse proxy
+
+Run rss-fulltext on loopback and put a reverse proxy in front for TLS and
+hostname routing. Examples:
+
+### Caddy
+
+```
+rss.example.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+Caddy will obtain and renew a Let's Encrypt certificate automatically.
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name rss.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/rss.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/rss.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Traefik (Docker)
+
+Add labels to the `rss-fulltext` service in `docker-compose.yml`:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.rss.rule=Host(`rss.example.com`)"
+  - "traefik.http.routers.rss.entrypoints=websecure"
+  - "traefik.http.routers.rss.tls.certresolver=letsencrypt"
+  - "traefik.http.services.rss.loadbalancer.server.port=8080"
+```
+
+The container does not need `ports:` published when behind Traefik on the same
+Docker network.
+
+> **Note.** `/metrics` shares the same listener as the feed plane. If you
+> expose the service publicly (e.g. `LISTEN_ADDR=:8080` plus a public reverse
+> proxy), restrict `/metrics` at the proxy or only proxy `/<name>.{xml,atom,json}`
+> and `/feeds.json`.
 
 ## Persistence
 
 Compose creates a named volume `data` mounted at `/var/lib/rss-fulltext`. It
-holds the generated `.xml` files and the article cache. Inspect with:
+holds the generated feed files and the article cache. Inspect with:
 
 ```sh
 docker compose exec rss-fulltext ls /var/lib/rss-fulltext/feeds
@@ -103,8 +215,8 @@ generated feeds. The feeds will be regenerated on next start.
 image: ghcr.io/mijndert/rss-fulltext:1.2.3
 ```
 
-Tagged versions are published by the `docker` workflow when a `vX.Y.Z` git tag
-is pushed.
+Tagged versions (`vX.Y.Z`) publish both Docker images and pre-built binaries
+via GitHub Releases.
 
 ## Building locally
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gorilla/feeds v1.2.0
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mmcdole/gofeed v1.3.0
+	golang.org/x/net v0.41.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -23,6 +24,5 @@ require (
 	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 )

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -22,6 +22,11 @@ type Cache interface {
 	Set(key, value string)
 }
 
+// Metrics is the optional metric sink for the extractor. Pass nil to disable.
+type Metrics interface {
+	RecordExtract(outcome string)
+}
+
 var (
 	ErrInvalidURL         = errors.New("invalid article url")
 	ErrUpstreamStatus     = errors.New("upstream returned non-2xx")
@@ -37,6 +42,7 @@ type Config struct {
 	CacheTTL    time.Duration
 	NegativeTTL time.Duration
 	Sanitizer   *bluemonday.Policy
+	Metrics     Metrics
 	Logger      *slog.Logger
 }
 
@@ -48,6 +54,7 @@ type Extractor struct {
 	cacheTTL    time.Duration
 	negativeTTL time.Duration
 	sanitizer   *bluemonday.Policy
+	metrics     Metrics
 	logger      *slog.Logger
 }
 
@@ -78,7 +85,14 @@ func New(cfg Config) *Extractor {
 		cacheTTL:    cfg.CacheTTL,
 		negativeTTL: cfg.NegativeTTL,
 		sanitizer:   cfg.Sanitizer,
+		metrics:     cfg.Metrics,
 		logger:      cfg.Logger,
+	}
+}
+
+func (e *Extractor) recordOutcome(outcome string) {
+	if e.metrics != nil {
+		e.metrics.RecordExtract(outcome)
 	}
 }
 
@@ -145,23 +159,33 @@ func classToErr(class string) error {
 }
 
 func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, error) {
+	// outcome defaults to "error" so any return-path we forget to label still
+	// gets counted somewhere. Update it as we classify failures and success.
+	outcome := "error"
+	defer func() { e.recordOutcome(outcome) }()
+
 	if entry, ok := e.cacheGet(articleURL); ok {
 		if entry.ErrClass != "" {
+			outcome = "cache_negative"
 			return "", classToErr(entry.ErrClass)
 		}
+		outcome = "cache_hit"
 		return entry.Body, nil
 	}
 
 	parsed, err := url.Parse(articleURL)
 	if err != nil {
+		outcome = "invalid_url"
 		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
 	}
 	if !parsed.IsAbs() || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		outcome = "invalid_url"
 		return "", fmt.Errorf("%w: scheme must be http(s)", ErrInvalidURL)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, articleURL, nil)
 	if err != nil {
+		outcome = "fetch_error"
 		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("User-Agent", e.userAgent)
@@ -169,6 +193,7 @@ func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, err
 
 	resp, err := e.client.Do(req)
 	if err != nil {
+		outcome = "fetch_error"
 		return "", fmt.Errorf("fetch article: %w", err)
 	}
 	defer func() {
@@ -177,6 +202,7 @@ func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, err
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		outcome = "upstream"
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			e.cacheNegative(articleURL, "upstream")
 		}
@@ -186,11 +212,13 @@ func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, err
 	if ct := resp.Header.Get("Content-Type"); ct != "" {
 		media, _, err := mime.ParseMediaType(ct)
 		if err != nil {
+			outcome = "unsupported"
 			e.cacheNegative(articleURL, "unsupported")
 			return "", fmt.Errorf("%w: %q", ErrUnsupportedContent, ct)
 		}
 		media = strings.ToLower(media)
 		if media != "text/html" && media != "application/xhtml+xml" {
+			outcome = "unsupported"
 			e.cacheNegative(articleURL, "unsupported")
 			return "", fmt.Errorf("%w: %s", ErrUnsupportedContent, media)
 		}
@@ -198,9 +226,11 @@ func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, err
 
 	article, err := readability.FromReader(io.LimitReader(resp.Body, e.maxBytes), parsed)
 	if err != nil {
+		outcome = "render_error"
 		return "", fmt.Errorf("readability: %w", err)
 	}
 	if article.Node == nil {
+		outcome = "empty"
 		e.cacheNegative(articleURL, "empty")
 		return "", ErrEmptyContent
 	}
@@ -208,11 +238,13 @@ func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, err
 
 	var rendered strings.Builder
 	if err := article.RenderHTML(&rendered); err != nil {
+		outcome = "render_error"
 		return "", fmt.Errorf("readability render: %w", err)
 	}
 
 	content := strings.TrimSpace(e.sanitizer.Sanitize(rendered.String()))
 	if content == "" {
+		outcome = "empty"
 		e.cacheNegative(articleURL, "empty")
 		return "", ErrEmptyContent
 	}
@@ -224,5 +256,6 @@ func (e *Extractor) Extract(ctx context.Context, articleURL string) (string, err
 			e.cacheSet(finalURL, entry)
 		}
 	}
+	outcome = "ok"
 	return content, nil
 }

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -45,6 +45,37 @@ func newExtractor(t *testing.T, cache Cache) *Extractor {
 	})
 }
 
+type recordingMetrics struct {
+	mu       sync.Mutex
+	outcomes []string
+}
+
+func (r *recordingMetrics) RecordExtract(outcome string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.outcomes = append(r.outcomes, outcome)
+}
+
+func (r *recordingMetrics) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.outcomes))
+	copy(out, r.outcomes)
+	return out
+}
+
+func newExtractorWithMetrics(t *testing.T, cache Cache, m Metrics) *Extractor {
+	t.Helper()
+	return New(Config{
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		UserAgent:  "test/1.0",
+		MaxBytes:   1 << 20,
+		Cache:      cache,
+		Metrics:    m,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
 func TestSanitizeStripsScripts(t *testing.T) {
 	e := newExtractor(t, nil)
 	got := e.Sanitize(`<p>Hello</p><script>alert(1)</script>`)
@@ -220,6 +251,97 @@ func TestExtractNegativeCachesOnUnsupportedContent(t *testing.T) {
 	}
 	if got := hits.Load(); got != 1 {
 		t.Errorf("expected unsupported-content to be negative-cached, got %d upstream hits", got)
+	}
+}
+
+func TestExtractRecordsOutcomes(t *testing.T) {
+	htmlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, articleHTML)
+	}))
+	defer htmlServer.Close()
+
+	gone := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	}))
+	defer gone.Close()
+
+	jsonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer jsonServer.Close()
+
+	emptyHTML := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, `<html><head></head><body></body></html>`)
+	}))
+	defer emptyHTML.Close()
+
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"ok", htmlServer.URL + "/article", "ok"},
+		{"invalid-url", "not-a-url", "invalid_url"},
+		{"bad-scheme", "ftp://example.com/x", "invalid_url"},
+		{"fetch-error", "http://127.0.0.1:1/dead", "fetch_error"},
+		{"upstream-4xx", gone.URL + "/dead", "upstream"},
+		{"unsupported", jsonServer.URL + "/x", "unsupported"},
+		{"empty", emptyHTML.URL + "/x", "empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingMetrics{}
+			e := newExtractorWithMetrics(t, nil, rec)
+			_, _ = e.Extract(context.Background(), tc.url)
+			got := rec.snapshot()
+			if len(got) != 1 || got[0] != tc.want {
+				t.Errorf("outcomes = %v, want [%s]", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractRecordsCacheOutcomes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, articleHTML)
+	}))
+	defer srv.Close()
+
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	}))
+	defer dead.Close()
+
+	cache := newMemCache()
+	rec := &recordingMetrics{}
+	e := newExtractorWithMetrics(t, cache, rec)
+
+	if _, err := e.Extract(context.Background(), srv.URL+"/a"); err != nil {
+		t.Fatalf("warm: %v", err)
+	}
+	if _, err := e.Extract(context.Background(), srv.URL+"/a"); err != nil {
+		t.Fatalf("cache hit: %v", err)
+	}
+	if _, err := e.Extract(context.Background(), dead.URL+"/dead"); err == nil {
+		t.Fatal("expected 4xx error")
+	}
+	if _, err := e.Extract(context.Background(), dead.URL+"/dead"); err == nil {
+		t.Fatal("expected cached 4xx error")
+	}
+
+	got := rec.snapshot()
+	want := []string{"ok", "cache_hit", "upstream", "cache_negative"}
+	if len(got) != len(want) {
+		t.Fatalf("outcomes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("outcome[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -26,17 +26,24 @@ type Extractor interface {
 	Sanitize(s string) string
 }
 
+// Metrics is the optional metric sink for the generator. Pass nil to disable.
+type Metrics interface {
+	RecordRefresh(feed, outcome string, duration time.Duration)
+	RecordRefreshSuccess(feed string, at time.Time, items int)
+}
+
 type Status struct {
-	Name          string    `json:"name"`
-	Title         string    `json:"title,omitempty"`
-	SourceURL     string    `json:"source_url"`
-	FileURL       string    `json:"file_url"`
-	Interval      string    `json:"interval"`
-	LastRefreshAt time.Time `json:"last_refresh_at,omitempty"`
-	LastSuccessAt time.Time `json:"last_success_at,omitempty"`
-	LastRefreshOK bool      `json:"last_refresh_ok"`
-	LastError     string    `json:"last_error,omitempty"`
-	ItemCount     int       `json:"item_count"`
+	Name          string            `json:"name"`
+	Title         string            `json:"title,omitempty"`
+	SourceURL     string            `json:"source_url"`
+	FileURL       string            `json:"file_url"`
+	Formats       map[string]string `json:"formats,omitempty"`
+	Interval      string            `json:"interval"`
+	LastRefreshAt time.Time         `json:"last_refresh_at,omitempty"`
+	LastSuccessAt time.Time         `json:"last_success_at,omitempty"`
+	LastRefreshOK bool              `json:"last_refresh_ok"`
+	LastError     string            `json:"last_error,omitempty"`
+	ItemCount     int               `json:"item_count"`
 }
 
 type Tracker struct {
@@ -87,6 +94,7 @@ type WorkerConfig struct {
 	MaxStaleness time.Duration
 	UserAgent    string
 	Tracker      *Tracker
+	Metrics      Metrics
 	Logger       *slog.Logger
 }
 
@@ -141,10 +149,20 @@ func (w *Worker) Run(ctx context.Context) {
 	}
 }
 
-func (w *Worker) Refresh(parent context.Context) error {
+func (w *Worker) Refresh(parent context.Context) (err error) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(parent, w.cfg.FeedTimeout)
 	defer cancel()
+	defer func() {
+		if w.cfg.Metrics == nil {
+			return
+		}
+		outcome := "ok"
+		if err != nil {
+			outcome = "fail"
+		}
+		w.cfg.Metrics.RecordRefresh(w.cfg.Feed.Name, outcome, time.Since(start))
+	}()
 
 	body, err := w.fetchFeed(ctx)
 	if err != nil {
@@ -170,7 +188,7 @@ func (w *Worker) Refresh(parent context.Context) error {
 		return w.handleEmpty(start, out)
 	}
 
-	if err := w.writeAtomic(out); err != nil {
+	if err := w.writeOutputs(out); err != nil {
 		return w.failRefresh(start, fmt.Errorf("write: %w", err))
 	}
 
@@ -181,6 +199,9 @@ func (w *Worker) Refresh(parent context.Context) error {
 		s.LastError = ""
 		s.ItemCount = len(out.Items)
 	})
+	if w.cfg.Metrics != nil {
+		w.cfg.Metrics.RecordRefreshSuccess(w.cfg.Feed.Name, start, len(out.Items))
+	}
 	w.cfg.Logger.Info("refreshed",
 		"feed", w.cfg.Feed.Name,
 		"items", len(out.Items),
@@ -206,7 +227,7 @@ func (w *Worker) handleEmpty(start time.Time, out *feeds.Feed) error {
 			"feed", w.cfg.Feed.Name,
 			"age", age,
 			"budget", w.cfg.MaxStaleness)
-		if err := w.writeAtomic(out); err != nil {
+		if err := w.writeOutputs(out); err != nil {
 			return w.failRefresh(start, fmt.Errorf("write empty: %w", err))
 		}
 		w.cfg.Tracker.update(w.cfg.Feed.Name, func(s *Status) {
@@ -339,47 +360,106 @@ func (w *Worker) itemFor(ctx context.Context, in *gofeed.Item) *feeds.Item {
 	return item
 }
 
-func (w *Worker) writeAtomic(out *feeds.Feed) error {
+// outputFormats lists every serialization the worker emits per refresh.
+// Order matters only for cleanup semantics: all temp files are staged first,
+// then renamed in this order, so .xml (the primary, also used for staleness
+// checks) is published before its alternates.
+var outputFormats = []struct {
+	ext   string
+	write func(*feeds.Feed, io.Writer) error
+}{
+	{".xml", func(f *feeds.Feed, w io.Writer) error { return f.WriteRss(w) }},
+	{".atom", func(f *feeds.Feed, w io.Writer) error { return f.WriteAtom(w) }},
+	{".json", func(f *feeds.Feed, w io.Writer) error { return f.WriteJSON(w) }},
+}
+
+// writeOutputs writes every format in outputFormats to disk.
+//
+// Atomicity policy: all formats are staged (write + fsync + chmod) to dotfile
+// temp files in the output dir before any rename happens. A staging failure
+// surfaces as an error and leaves the previous published files untouched.
+//
+// Rename phase: temp files are renamed into place sequentially. Rename within
+// a single directory after fsync is effectively infallible on the filesystems
+// we run on (ext4, APFS), so partial-rename failure is unreachable in
+// practice. If it does happen (e.g. ENOSPC, EROFS race), readers may briefly
+// see a mix of fresh and stale formats for one feed — the next refresh
+// restores consistency. We accept this rather than carrying backup copies of
+// each previous file just to support an unreachable rollback.
+func (w *Worker) writeOutputs(out *feeds.Feed) error {
 	if err := os.MkdirAll(w.cfg.OutputDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
-	final := w.OutputFile()
-	tmp, err := os.CreateTemp(w.cfg.OutputDir, "."+w.cfg.Feed.Name+".xml.*")
-	if err != nil {
-		return fmt.Errorf("tempfile: %w", err)
-	}
-	name := tmp.Name()
+
+	type staged struct{ tmp, final string }
+	stagedFiles := make([]staged, 0, len(outputFormats))
 	cleanup := true
 	defer func() {
 		if cleanup {
+			for _, s := range stagedFiles {
+				_ = os.Remove(s.tmp)
+			}
+		}
+	}()
+
+	for _, f := range outputFormats {
+		final := filepath.Join(w.cfg.OutputDir, w.cfg.Feed.Name+f.ext)
+		name, err := w.stageFile(out, f.ext, f.write)
+		if err != nil {
+			return err
+		}
+		stagedFiles = append(stagedFiles, staged{tmp: name, final: final})
+	}
+
+	// Past this point the deferred cleanup must not delete files we've already
+	// renamed into place. Disable it; per-iteration failures leave only the
+	// not-yet-renamed temp files, which we remove inline.
+	cleanup = false
+	for i, s := range stagedFiles {
+		if err := os.Rename(s.tmp, s.final); err != nil {
+			for _, leftover := range stagedFiles[i:] {
+				_ = os.Remove(leftover.tmp)
+			}
+			return fmt.Errorf("rename %s: %w", filepath.Base(s.final), err)
+		}
+	}
+	return nil
+}
+
+func (w *Worker) stageFile(out *feeds.Feed, ext string, write func(*feeds.Feed, io.Writer) error) (string, error) {
+	tmp, err := os.CreateTemp(w.cfg.OutputDir, "."+w.cfg.Feed.Name+ext+".*")
+	if err != nil {
+		return "", fmt.Errorf("tempfile %s: %w", ext, err)
+	}
+	name := tmp.Name()
+	ok := false
+	defer func() {
+		if !ok {
 			_ = os.Remove(name)
 		}
 	}()
 
 	bw := bufio.NewWriter(tmp)
-	if err := out.WriteRss(bw); err != nil {
+	if err := write(out, bw); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("write rss: %w", err)
+		return "", fmt.Errorf("write %s: %w", ext, err)
 	}
 	if err := bw.Flush(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("flush: %w", err)
+		return "", fmt.Errorf("flush %s: %w", ext, err)
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("sync: %w", err)
+		return "", fmt.Errorf("sync %s: %w", ext, err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close: %w", err)
+		return "", fmt.Errorf("close %s: %w", ext, err)
 	}
 	if err := os.Chmod(name, 0o644); err != nil {
-		return fmt.Errorf("chmod: %w", err)
+		return "", fmt.Errorf("chmod %s: %w", ext, err)
 	}
-	if err := os.Rename(name, final); err != nil {
-		return fmt.Errorf("rename: %w", err)
-	}
-	cleanup = false
-	return nil
+	ok = true
+	return name, nil
 }
 
 func firstNonEmpty(vs ...string) string {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -191,6 +191,55 @@ func TestRefreshWritesFeed(t *testing.T) {
 	}
 }
 
+func TestRefreshWritesAllFormats(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = io.WriteString(w, sampleRSS)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	w := newWorker(t, srv.URL, dir, &fakeExtractor{content: "extracted-body-marker"})
+	w.cfg.Tracker.Init(w.cfg.Feed.Name, Status{Name: w.cfg.Feed.Name})
+
+	if err := w.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	cases := []struct {
+		ext      string
+		contains []string
+	}{
+		{".xml", []string{"<rss", "Item One", "extracted-body-marker"}},
+		{".atom", []string{"<feed", "Item One", "extracted-body-marker"}},
+		{".json", []string{`"version"`, "Item One", "extracted-body-marker"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ext, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join(dir, "sample"+tc.ext))
+			if err != nil {
+				t.Fatalf("read %s output: %v", tc.ext, err)
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(string(body), want) {
+					t.Errorf("%s output missing %q. body=%s", tc.ext, want, body)
+				}
+			}
+		})
+	}
+
+	// No stray dotfiles (temp files) should be left behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			t.Errorf("unexpected leftover temp file: %s", e.Name())
+		}
+	}
+}
+
 const maliciousRSS = `<?xml version="1.0"?>
 <rss version="2.0"><channel>
 <title>Malicious</title>

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,343 @@
+// Package metrics provides a tiny in-process Prometheus exposition.
+//
+// It deliberately avoids the prometheus/client_golang dependency: the
+// metric set is small and the text format is stable. Counters and gauges
+// are the only supported metric kinds.
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const contentType = "text/plain; version=0.0.4; charset=utf-8"
+
+type kind int
+
+const (
+	kindCounter kind = iota
+	kindGauge
+)
+
+func (k kind) String() string {
+	if k == kindCounter {
+		return "counter"
+	}
+	return "gauge"
+}
+
+type metric struct {
+	name   string
+	help   string
+	kind   kind
+	labels []string
+
+	mu     sync.Mutex
+	values map[string]float64 // label-value key -> value
+}
+
+// Registry holds metric definitions and their values.
+type Registry struct {
+	mu      sync.RWMutex
+	metrics map[string]*metric
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{metrics: make(map[string]*metric)}
+}
+
+// Handler returns an http.Handler that serves the Prometheus text exposition.
+func (r *Registry) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Cache-Control", "no-store")
+		_ = r.WriteText(w)
+	})
+}
+
+// WriteText writes the current snapshot in Prometheus text format.
+func (r *Registry) WriteText(w io.Writer) error {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.metrics))
+	for n := range r.metrics {
+		names = append(names, n)
+	}
+	r.mu.RUnlock()
+	sort.Strings(names)
+
+	for _, n := range names {
+		r.mu.RLock()
+		m := r.metrics[n]
+		r.mu.RUnlock()
+		if err := m.writeText(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Registry) register(name, help string, k kind, labels []string) *metric {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if m, ok := r.metrics[name]; ok {
+		// Caller asked for the same metric twice; return the existing
+		// definition so the resulting Counter/Gauge wrapper still points
+		// at the live value map. Mismatched re-registration is a bug.
+		if m.kind != k || !equalLabels(m.labels, labels) {
+			panic(fmt.Sprintf("metrics: %s re-registered with different shape", name))
+		}
+		return m
+	}
+	m := &metric{
+		name:   name,
+		help:   help,
+		kind:   k,
+		labels: append([]string(nil), labels...),
+		values: make(map[string]float64),
+	}
+	r.metrics[name] = m
+	return m
+}
+
+func (m *metric) writeText(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "# HELP %s %s\n", m.name, escapeHelp(m.help)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "# TYPE %s %s\n", m.name, m.kind); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	keys := make([]string, 0, len(m.values))
+	for k := range m.values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := m.values[k]
+		if len(m.labels) == 0 {
+			if _, err := fmt.Fprintf(w, "%s %s\n", m.name, formatFloat(v)); err != nil {
+				m.mu.Unlock()
+				return err
+			}
+			continue
+		}
+		parts := strings.Split(k, "\x00")
+		var sb strings.Builder
+		sb.WriteString(m.name)
+		sb.WriteByte('{')
+		for i, lbl := range m.labels {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(lbl)
+			sb.WriteString(`="`)
+			sb.WriteString(escapeLabelValue(parts[i]))
+			sb.WriteByte('"')
+		}
+		sb.WriteByte('}')
+		sb.WriteByte(' ')
+		sb.WriteString(formatFloat(v))
+		sb.WriteByte('\n')
+		if _, err := io.WriteString(w, sb.String()); err != nil {
+			m.mu.Unlock()
+			return err
+		}
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *metric) labelKey(values []string) string {
+	if len(values) != len(m.labels) {
+		panic(fmt.Sprintf("metrics: %s expects %d label values, got %d", m.name, len(m.labels), len(values)))
+	}
+	return strings.Join(values, "\x00")
+}
+
+// Counter is a monotonically increasing value.
+type Counter struct{ m *metric }
+
+// NewCounter registers (or retrieves) a counter with the given labels.
+func (r *Registry) NewCounter(name, help string, labels ...string) *Counter {
+	return &Counter{m: r.register(name, help, kindCounter, labels)}
+}
+
+// Inc increments by 1.
+func (c *Counter) Inc(labelValues ...string) { c.Add(1, labelValues...) }
+
+// Add adds delta. Negative deltas panic — counters are monotonic.
+func (c *Counter) Add(delta float64, labelValues ...string) {
+	if delta < 0 {
+		panic(fmt.Sprintf("metrics: counter %s decremented by %v", c.m.name, delta))
+	}
+	key := c.m.labelKey(labelValues)
+	c.m.mu.Lock()
+	c.m.values[key] += delta
+	c.m.mu.Unlock()
+}
+
+// Gauge is an arbitrary instantaneous value.
+type Gauge struct{ m *metric }
+
+// NewGauge registers (or retrieves) a gauge with the given labels.
+func (r *Registry) NewGauge(name, help string, labels ...string) *Gauge {
+	return &Gauge{m: r.register(name, help, kindGauge, labels)}
+}
+
+// Set sets the gauge to v.
+func (g *Gauge) Set(v float64, labelValues ...string) {
+	key := g.m.labelKey(labelValues)
+	g.m.mu.Lock()
+	g.m.values[key] = v
+	g.m.mu.Unlock()
+}
+
+// Metrics is the concrete set of metrics this binary publishes.
+type Metrics struct {
+	registry        *Registry
+	refreshTotal    *Counter
+	refreshDuration *Gauge
+	refreshItems    *Gauge
+	refreshLastOK   *Gauge
+	extractTotal    *Counter
+}
+
+// New returns a fully-registered Metrics bound to a fresh registry.
+func New() *Metrics {
+	r := NewRegistry()
+	return &Metrics{
+		registry: r,
+		refreshTotal: r.NewCounter(
+			"rss_fulltext_refresh_total",
+			"Number of feed refresh attempts by outcome (ok|fail).",
+			"feed", "outcome",
+		),
+		refreshDuration: r.NewGauge(
+			"rss_fulltext_refresh_duration_seconds",
+			"Duration of the most recent refresh attempt, in seconds.",
+			"feed",
+		),
+		refreshItems: r.NewGauge(
+			"rss_fulltext_refresh_items",
+			"Item count from the most recent successful refresh.",
+			"feed",
+		),
+		refreshLastOK: r.NewGauge(
+			"rss_fulltext_refresh_last_success_timestamp_seconds",
+			"Unix timestamp (seconds) of the most recent successful refresh.",
+			"feed",
+		),
+		extractTotal: r.NewCounter(
+			"rss_fulltext_extract_total",
+			"Article extraction outcomes (ok|cache_hit|cache_negative|upstream|unsupported|empty|invalid_url|fetch_error|render_error|error).",
+			"outcome",
+		),
+	}
+}
+
+// Handler returns the /metrics handler bound to this metric set.
+func (m *Metrics) Handler() http.Handler {
+	if m == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.NotFound(w, &http.Request{})
+		})
+	}
+	return m.registry.Handler()
+}
+
+// RecordRefresh observes a refresh attempt and its duration.
+// outcome should be "ok" or "fail".
+func (m *Metrics) RecordRefresh(feed, outcome string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.refreshTotal.Inc(feed, outcome)
+	m.refreshDuration.Set(duration.Seconds(), feed)
+}
+
+// RecordRefreshSuccess records the item count and last-success timestamp
+// for a successful refresh. Only call this on success.
+func (m *Metrics) RecordRefreshSuccess(feed string, at time.Time, items int) {
+	if m == nil {
+		return
+	}
+	m.refreshItems.Set(float64(items), feed)
+	m.refreshLastOK.Set(float64(at.Unix()), feed)
+}
+
+// RecordExtract observes the outcome of a single article extraction.
+func (m *Metrics) RecordExtract(outcome string) {
+	if m == nil {
+		return
+	}
+	m.extractTotal.Inc(outcome)
+}
+
+func equalLabels(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// escapeLabelValue escapes per the Prometheus text format: \, ", and \n.
+func escapeLabelValue(s string) string {
+	if !strings.ContainsAny(s, "\\\"\n") {
+		return s
+	}
+	var sb strings.Builder
+	sb.Grow(len(s) + 4)
+	for _, r := range s {
+		switch r {
+		case '\\':
+			sb.WriteString(`\\`)
+		case '"':
+			sb.WriteString(`\"`)
+		case '\n':
+			sb.WriteString(`\n`)
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// escapeHelp escapes per the Prometheus text format: \ and \n (no quote escaping).
+func escapeHelp(s string) string {
+	if !strings.ContainsAny(s, "\\\n") {
+		return s
+	}
+	var sb strings.Builder
+	sb.Grow(len(s) + 4)
+	for _, r := range s {
+		switch r {
+		case '\\':
+			sb.WriteString(`\\`)
+		case '\n':
+			sb.WriteString(`\n`)
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+func formatFloat(v float64) string {
+	if v == float64(int64(v)) {
+		return strconv.FormatInt(int64(v), 10)
+	}
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,141 @@
+package metrics
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCounterAndGaugeOutput(t *testing.T) {
+	m := New()
+	m.RecordRefresh("tc", "ok", 1500*time.Millisecond)
+	m.RecordRefresh("tc", "ok", 2*time.Second)
+	m.RecordRefresh("tc", "fail", 500*time.Millisecond)
+	m.RecordRefreshSuccess("tc", time.Unix(1700000000, 0), 42)
+	m.RecordExtract("ok")
+	m.RecordExtract("ok")
+	m.RecordExtract("cache_hit")
+
+	var buf bytes.Buffer
+	if err := m.registry.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	got := buf.String()
+
+	wants := []string{
+		`# HELP rss_fulltext_refresh_total`,
+		`# TYPE rss_fulltext_refresh_total counter`,
+		`rss_fulltext_refresh_total{feed="tc",outcome="ok"} 2`,
+		`rss_fulltext_refresh_total{feed="tc",outcome="fail"} 1`,
+		`# TYPE rss_fulltext_refresh_duration_seconds gauge`,
+		`rss_fulltext_refresh_duration_seconds{feed="tc"} 0.5`,
+		`rss_fulltext_refresh_items{feed="tc"} 42`,
+		`rss_fulltext_refresh_last_success_timestamp_seconds{feed="tc"} 1700000000`,
+		`rss_fulltext_extract_total{outcome="ok"} 2`,
+		`rss_fulltext_extract_total{outcome="cache_hit"} 1`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("output missing %q\n--- got ---\n%s", w, got)
+		}
+	}
+}
+
+func TestHandlerServesPlainText(t *testing.T) {
+	m := New()
+	m.RecordExtract("ok")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q, want text/plain*", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "rss_fulltext_extract_total") {
+		t.Errorf("body missing extract counter: %s", rec.Body.String())
+	}
+}
+
+func TestLabelEscaping(t *testing.T) {
+	r := NewRegistry()
+	c := r.NewCounter("test_total", "with \\back and\nnewline.", "feed")
+	c.Inc(`weird"\name`)
+
+	var buf bytes.Buffer
+	if err := r.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, `# HELP test_total with \\back and\nnewline.`) {
+		t.Errorf("help text not escaped: %s", got)
+	}
+	if !strings.Contains(got, `test_total{feed="weird\"\\name"} 1`) {
+		t.Errorf("label value not escaped: %s", got)
+	}
+}
+
+func TestCounterNegativeAddPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on negative counter Add")
+		}
+	}()
+	r := NewRegistry()
+	c := r.NewCounter("t", "h")
+	c.Add(-1)
+}
+
+func TestMismatchedRegisterPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on mismatched re-registration")
+		}
+	}()
+	r := NewRegistry()
+	_ = r.NewCounter("t", "h", "feed")
+	_ = r.NewCounter("t", "h", "feed", "outcome") // different shape
+}
+
+func TestNilSinkSafe(t *testing.T) {
+	var m *Metrics
+	// Calls on a nil receiver must not panic; this matches how callers may
+	// be configured (Metrics: nil).
+	m.RecordRefresh("x", "ok", time.Second)
+	m.RecordRefreshSuccess("x", time.Now(), 1)
+	m.RecordExtract("ok")
+	// Handler() on nil returns a 404 handler; verify it doesn't panic.
+	h := m.Handler()
+	if h == nil {
+		t.Fatal("Handler() returned nil")
+	}
+}
+
+func TestConcurrentUpdatesAreCounted(t *testing.T) {
+	m := New()
+	const N = 200
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			m.RecordExtract("ok")
+		}()
+	}
+	wg.Wait()
+
+	var buf bytes.Buffer
+	if err := m.registry.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	if !strings.Contains(buf.String(), `rss_fulltext_extract_total{outcome="ok"} 200`) {
+		t.Errorf("expected 200 ok extracts, got:\n%s", buf.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,13 +13,16 @@ import (
 type Config struct {
 	OutputDir string
 	Tracker   *generator.Tracker
-	Logger    *slog.Logger
+	// Metrics is the /metrics handler. Nil disables the endpoint.
+	Metrics http.Handler
+	Logger  *slog.Logger
 }
 
 type Server struct {
 	outputDir string
 	tracker   *generator.Tracker
 	fileSrv   http.Handler
+	metrics   http.Handler
 	logger    *slog.Logger
 }
 
@@ -31,6 +34,7 @@ func New(cfg Config) *Server {
 		outputDir: cfg.OutputDir,
 		tracker:   cfg.Tracker,
 		fileSrv:   http.FileServer(safeDir(cfg.OutputDir)),
+		metrics:   cfg.Metrics,
 		logger:    cfg.Logger,
 	}
 }
@@ -39,6 +43,9 @@ func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.handleHealth)
 	mux.HandleFunc("GET /feeds.json", s.handleListFeeds)
+	if s.metrics != nil {
+		mux.Handle("GET /metrics", s.metrics)
+	}
 	mux.HandleFunc("GET /", s.handleStatic)
 	return mux
 }
@@ -54,6 +61,14 @@ func (s *Server) handleListFeeds(w http.ResponseWriter, _ *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{"feeds": s.tracker.Snapshot()})
 }
 
+// feedContentTypes maps the served file extension to its canonical media type.
+// Extensions not in this map are rejected with 404.
+var feedContentTypes = map[string]string{
+	".xml":  "application/rss+xml; charset=utf-8",
+	".atom": "application/atom+xml; charset=utf-8",
+	".json": "application/feed+json; charset=utf-8",
+}
+
 func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	if path == "/" {
@@ -65,11 +80,13 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if !strings.HasSuffix(name, ".xml") {
+	ext := filepath.Ext(name)
+	ct, ok := feedContentTypes[ext]
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-	w.Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
+	w.Header().Set("Content-Type", ct)
 	w.Header().Set("Cache-Control", "public, max-age=60")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	s.fileSrv.ServeHTTP(w, r)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -71,21 +71,69 @@ func TestFeedsJSON(t *testing.T) {
 	}
 }
 
-func TestServesXMLFile(t *testing.T) {
+func TestServesFeedFiles(t *testing.T) {
 	s, dir := newTestServer(t)
-	if err := os.WriteFile(filepath.Join(dir, "example.xml"), []byte("<rss/>"), 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
+	for _, name := range []string{"example.xml", "example.atom", "example.json"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("payload"), 0o644); err != nil {
+			t.Fatalf("write fixture %s: %v", name, err)
+		}
 	}
 
-	rec := doRequest(t, s.Routes(), "/example.xml")
+	cases := []struct {
+		path string
+		ct   string
+	}{
+		{"/example.xml", "application/rss+xml"},
+		{"/example.atom", "application/atom+xml"},
+		{"/example.json", "application/feed+json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			rec := doRequest(t, s.Routes(), tc.path)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, tc.ct) {
+				t.Errorf("content-type = %q, want %q", ct, tc.ct)
+			}
+			if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
+				t.Error("X-Content-Type-Options header missing")
+			}
+		})
+	}
+}
+
+func TestMetricsEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	tr := generator.NewTracker()
+	tr.Init("example", generator.Status{Name: "example"})
+	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("rss_fulltext_test 1\n"))
+	})
+	s := New(Config{
+		OutputDir: dir,
+		Tracker:   tr,
+		Metrics:   metricsHandler,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	rec := doRequest(t, s.Routes(), "/metrics")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/rss+xml") {
-		t.Errorf("content-type = %q, want rss+xml", ct)
+	if !strings.Contains(rec.Body.String(), "rss_fulltext_test 1") {
+		t.Errorf("metrics body unexpected: %s", rec.Body.String())
 	}
-	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
-		t.Error("X-Content-Type-Options header missing")
+}
+
+func TestMetricsEndpointDisabledWhenNil(t *testing.T) {
+	// When no metrics handler is configured, /metrics should not be mounted
+	// and the fallback static handler will reject it (no .xml extension).
+	s, _ := newTestServer(t)
+	rec := doRequest(t, s.Routes(), "/metrics")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"rss-fulltext/internal/extractor"
 	"rss-fulltext/internal/filecache"
 	"rss-fulltext/internal/generator"
+	"rss-fulltext/internal/metrics"
 	"rss-fulltext/internal/safehttp"
 	"rss-fulltext/internal/server"
 )
@@ -60,6 +61,8 @@ func main() {
 		AllowPrivateAddresses: cfg.AllowPrivateAddresses,
 	})
 
+	mx := metrics.New()
+
 	ext := extractor.New(extractor.Config{
 		HTTPClient:  client,
 		UserAgent:   cfg.UserAgent,
@@ -67,6 +70,7 @@ func main() {
 		Cache:       cache,
 		CacheTTL:    cfg.CacheTTL,
 		NegativeTTL: cfg.NegativeCacheTTL,
+		Metrics:     mx,
 		Logger:      logger,
 	})
 
@@ -77,13 +81,19 @@ func main() {
 			Title:     f.Title,
 			SourceURL: f.URL,
 			FileURL:   "/" + f.Name + ".xml",
-			Interval:  f.Interval.String(),
+			Formats: map[string]string{
+				"rss":  "/" + f.Name + ".xml",
+				"atom": "/" + f.Name + ".atom",
+				"json": "/" + f.Name + ".json",
+			},
+			Interval: f.Interval.String(),
 		})
 	}
 
 	srv := server.New(server.Config{
 		OutputDir: cfg.OutputDir,
 		Tracker:   tracker,
+		Metrics:   mx.Handler(),
 		Logger:    logger,
 	})
 
@@ -123,6 +133,7 @@ func main() {
 			MaxStaleness: cfg.MaxStaleness,
 			UserAgent:    cfg.UserAgent,
 			Tracker:      tracker,
+			Metrics:      mx,
 			Logger:       logger,
 		})
 		delay := time.Duration(i) * 500 * time.Millisecond

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -22,9 +24,97 @@ import (
 	"rss-fulltext/internal/server"
 )
 
+// Version metadata populated by goreleaser via -ldflags.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "version", "--version", "-v":
+			fmt.Printf("rss-fulltext %s (commit %s, built %s)\n", version, commit, date)
+			return
+		case "healthcheck":
+			os.Exit(runHealthcheck())
+		case "help", "--help", "-h":
+			printUsage(os.Stdout)
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "unknown subcommand: %s\n\n", os.Args[1])
+			printUsage(os.Stderr)
+			os.Exit(2)
+		}
+	}
+	runServer()
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: rss-fulltext [healthcheck|version|help]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  (no args)     run the HTTP server and refresh workers")
+	fmt.Fprintln(w, "  healthcheck   probe http://127.0.0.1:<port>/healthz, exit 0 on success")
+	fmt.Fprintln(w, "  version       print the version and exit")
+	fmt.Fprintln(w, "  help          print this message")
+}
+
+// runHealthcheck performs an HTTP GET against the local /healthz endpoint
+// and returns 0 on a 2xx response.
+func runHealthcheck() int {
+	addr := os.Getenv("LISTEN_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:8080"
+	}
+	target, err := healthcheckURL(addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: bad LISTEN_ADDR %q: %v\n", addr, err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: build request: %v\n", err)
+		return 1
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Fprintf(os.Stderr, "healthcheck: status %d\n", resp.StatusCode)
+		return 1
+	}
+	return 0
+}
+
+// healthcheckURL maps a LISTEN_ADDR value to a probe URL pointing at the
+// local interface. Wildcard hosts are rewritten to a valid destination
+// (loopback) so the probe still reaches the server when bound to all
+// interfaces.
+func healthcheckURL(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	switch host {
+	case "", "0.0.0.0":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	return "http://" + net.JoinHostPort(host, port) + "/healthz", nil
+}
+
+func runServer() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
+	logger.Info("starting", "version", version, "commit", commit)
 
 	cfg, err := loadConfig(logger)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthcheckSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	t.Setenv("LISTEN_ADDR", srv.Listener.Addr().String())
+
+	if got := runHealthcheck(); got != 0 {
+		t.Errorf("exit = %d, want 0", got)
+	}
+}
+
+func TestHealthcheckFailureOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	t.Setenv("LISTEN_ADDR", srv.Listener.Addr().String())
+
+	if got := runHealthcheck(); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+func TestHealthcheckFailureOnUnreachable(t *testing.T) {
+	// Port 1 is reserved and reliably refused; this exercises the dial-error path.
+	t.Setenv("LISTEN_ADDR", "127.0.0.1:1")
+	if got := runHealthcheck(); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+func TestHealthcheckFailureOnBadAddr(t *testing.T) {
+	t.Setenv("LISTEN_ADDR", "not-a-host-port")
+	if got := runHealthcheck(); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+func TestHealthcheckURLMapping(t *testing.T) {
+	cases := []struct {
+		addr string
+		want string
+	}{
+		{":8080", "http://127.0.0.1:8080/healthz"},
+		{"0.0.0.0:8080", "http://127.0.0.1:8080/healthz"},
+		{"127.0.0.1:8080", "http://127.0.0.1:8080/healthz"},
+		{"[::]:8080", "http://[::1]:8080/healthz"},
+		{"[::1]:8080", "http://[::1]:8080/healthz"},
+		{"10.0.0.5:9090", "http://10.0.0.5:9090/healthz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			got, err := healthcheckURL(tc.addr)
+			if err != nil {
+				t.Fatalf("healthcheckURL(%q): %v", tc.addr, err)
+			}
+			if got != tc.want {
+				t.Errorf("healthcheckURL(%q) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHealthcheckURLError(t *testing.T) {
+	if _, err := healthcheckURL("not-a-host-port"); err == nil {
+		t.Error("expected error on malformed addr")
+	}
+}


### PR DESCRIPTION
### Added
- Atom and JSON Feed output alongside RSS for every feed.
- `/metrics` endpoint (Prometheus text format).
- `healthcheck`, `version`, and `help` subcommands; Docker `HEALTHCHECK` uses the new subcommand.
- Pre-built binaries on every tag via GoReleaser (linux/macOS/FreeBSD × amd64/arm64 + checksums).
- `formats` map in `/feeds.json` listing each feed's RSS/Atom/JSON URLs.

### Changed
- README rewritten: one-line Docker quickstart, reverse-proxy recipes (Caddy/nginx/Traefik), hardening flags in the quickstart.
- Release workflow split into `docker` and `binaries` jobs with per-job least-privilege permissions.
- Atomic write now stages all three output formats before any rename.

### Fixed
- Extractor metric outcomes split out of the catch-all `error` bucket: `invalid_url`, `fetch_error`, `render_error`.